### PR TITLE
Added files via upload

### DIFF
--- a/AssaultSpecialist.cs
+++ b/AssaultSpecialist.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+	public class AssaultSpecialist : RotationBase
+	{
+		public override string Name
+		{
+			get { return "Commando Assault Specialist"; }
+		}
+
+		public override Composite Buffs
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Plasma Cell"),
+					Spell.Buff("Fortification")
+					);
+			}
+		}
+
+		public override Composite Cooldowns
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Tenacity", ret => Me.IsStunned),
+					Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 40),
+					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
+					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+					Spell.Buff("Supercharged Cell", ret => Me.BuffCount("Supercharge") == 10),
+					Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60)
+					);
+			}
+		}
+
+		public override Composite SingleTarget
+		{
+			get
+			{
+				return new PrioritySelector(
+                    
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
+
+                    new Decorator(ret => Me.ResourcePercent() > 40,
+						new PrioritySelector(
+							Spell.Cast("Mag Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level >= 57),
+							Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level < 57),
+							Spell.Cast("Hammer Shot")
+							)),
+
+
+
+					//Rotation
+					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled),
+					Spell.Cast("Mag Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level >= 57),
+					Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level < 57),
+					Spell.Cast("Explosive Round", ret => Me.HasBuff("Hyper Assault Rounds")),
+					Spell.Cast("Assault Plastique"),
+					Spell.DoT("Serrated Bolt", "Bleeding"),
+					Spell.DoT("Incendiary Round", "Burning (Incendiary Round)"),
+					Spell.Cast("Electro Net"),
+					Spell.Cast("Full Auto"),
+					Spell.Cast("Mag Bolt", ret => Me.Level >= 57),
+					Spell.Cast("High Impact Bolt", ret => Me.Level < 57),
+					Spell.Cast("Charged Bolts")
+					);
+			}
+		}
+
+		public override Composite AreaOfEffect
+		{
+			get
+			{
+				return new Decorator(ret => Targeting.ShouldAoe,
+					new PrioritySelector(
+						Spell.DoT("Serrated Bolt", "Bleeding"),
+						Spell.DoT("Incendiary Round", "Burning (Incendiary Round)"),
+						Spell.Cast("Plasma Grenade", ret => Me.CurrentTarget.HasDebuff("Burning (Incendiary Round)")),
+						Spell.Cast("Sticky Grenade", ret => Me.CurrentTarget.HasDebuff("Bleeding")),
+						Spell.Cast("Explosive Round", ret => Me.HasBuff("Hyper Assault Rounds")),
+						Spell.CastOnGround("Hail of Bolts", ret => Me.ResourcePercent() >= 90)
+						));
+			}
+		}
+	}
+}

--- a/Balance.cs
+++ b/Balance.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+	internal class Balance : RotationBase
+	{
+		public override string Name
+		{
+			get { return "Sage Balance"; }
+		}
+
+		public override Composite Buffs
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Force Valor")
+					);
+			}
+		}
+
+		public override Composite Cooldowns
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Force Barrier", ret => Me.HealthPercent <= 20),
+					Spell.Buff("Force Armor", ret => !Me.HasBuff("Force Armor") && !Me.HasDebuff("Force-imbalance")),
+					Spell.Buff("Force Mend", ret => Me.HealthPercent <= 50),
+					Spell.Buff("Mental Alacrity", ret => Me.CurrentTarget.BossOrGreater()),
+					Spell.Buff("Force Potency")
+					);
+			}
+		}
+
+		public override Composite SingleTarget
+		{
+			get
+			{
+				return new PrioritySelector(
+					//Movement
+					CombatMovement.CloseDistance(Distance.Ranged),
+					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled),
+					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled),
+					Spell.Cast("Vanquish", ret => Me.BuffCount("Presence of Mind") == 4 && Me.Level >= 57),
+					Spell.Cast("Mind Crush", ret => Me.BuffCount("Presence of Mind") == 4 && Me.Level < 57),
+					Spell.DoT("Weaken Mind", "Weaken Mind"),
+					Spell.DoT("Sever Force", "Sever Force"),
+					Spell.CastOnGround("Force in Balance",
+						ret => Me.CurrentTarget.HasDebuff("Weaken Mind") && Me.CurrentTarget.HasDebuff("Sever Force")),
+					Spell.Cast("Force Serenity", ret => Me.CurrentTarget.HasDebuff("Weaken Mind")),
+					Spell.Cast("Disturbance", ret => Me.BuffCount("Presence of Mind") == 4),
+					Spell.Cast("Telekinetic Throw", ret => Me.BuffCount("Presence of Mind") < 4)
+					);
+			}
+		}
+
+		public override Composite AreaOfEffect
+		{
+			get
+			{
+				return new Decorator(ret => Targeting.ShouldAoe,
+					new PrioritySelector(
+						Spell.DoT("Weaken Mind", "Weaken Mind"),
+						Spell.DoT("Sever Force", "Sever Force"),
+						Spell.CastOnGround("Force in Balance",
+							ret => Me.CurrentTarget.HasDebuff("Weaken Mind") && Me.CurrentTarget.HasDebuff("Sever Force")),
+						Spell.CastOnGround("Forcequake", ret => Me.CurrentTarget.HasDebuff("Overwhelmed (Mental)"))
+						));
+			}
+		}
+	}
+}

--- a/CombatHotkeys.cs
+++ b/CombatHotkeys.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System.Windows.Forms;
+using Buddy.Common;
+using DefaultCombat.Core;
+
+namespace DefaultCombat.Helpers
+{
+	public static class CombatHotkeys
+	{
+		public static bool EnableAoe;
+		public static bool PauseRotation;
+
+		public static void Initialize()
+		{
+			EnableAoe = true;
+			PauseRotation = false;
+
+			Hotkeys.RegisterHotkey("Toggle AOE (F7)", ChangeAoe, Keys.F7);
+			Logger.Write("[Hot Key][F7] Toggle AOE");
+
+			Hotkeys.RegisterHotkey("Pause Rotation (F8)", ChangePause, Keys.F8);
+			Logger.Write("[Hot Key][F8] Pause Rotation");
+
+			Hotkeys.RegisterHotkey("Set Tank (F12)", Targeting.SetTank, Keys.F12);
+			Logger.Write("[Hot Key][F12] Set Tank");
+		}
+
+		private static void ChangeAoe()
+		{
+			if (EnableAoe)
+			{
+				Logger.Write("AOE Disabled");
+				EnableAoe = false;
+			}
+			else
+			{
+				Logger.Write("AOE Enabled");
+				EnableAoe = true;
+			}
+		}
+
+		private static void ChangePause()
+		{
+			if (PauseRotation)
+			{
+				Logger.Write("Rotation Resumed");
+				PauseRotation = false;
+			}
+			else
+			{
+				Logger.Write("Rotation Paused");
+				PauseRotation = true;
+			}
+		}
+	}
+}

--- a/CombatMedic.cs
+++ b/CombatMedic.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH 
+// See the file LICENSE for the source code's detailed license 
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+    internal class CombatMedic : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Commando Combat Medic"; }
+        }
+
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification"),
+                    Spell.Buff("Combat Support Cell")
+                    );
+            }
+        }
+
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity"),
+                    Spell.Buff("Supercharged Cell",
+                        ret =>
+                            Me.ResourceStat >= 20 && HealTarget != null && HealTarget.HealthPercent <= 80 &&
+                            Me.BuffCount("Supercharge") == 10),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 50),
+                    Spell.Cast("Tech Override", ret => Tank != null && Tank.HealthPercent <= 50)
+                    );
+            }
+        }
+
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement 
+                    CombatMovement.CloseDistance(Distance.Ranged),
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting),
+                    Spell.Cast("High Impact Bolt"),
+                    Spell.Cast("Full Auto"),
+                    Spell.Cast("Charged Bolts", ret => Me.ResourceStat >= 70),
+                    Spell.Cast("Hammer Shot")
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+
+                    new Decorator(ret => Me.HasBuff("Supercharged Cell"),
+                        new PrioritySelector(
+                            Spell.HealGround("Kolto Bomb", ret => !Tank.HasBuff("Kolto Residue")),
+                            Spell.Heal("Bacta Infusion", 60),
+                            Spell.Heal("Advanced Medical Probe", 85)
+                            )),
+
+                    //Dispel 
+                    Spell.Cleanse("Field Aid"),
+
+                    //AoE Healing 
+                    Spell.HealAoe("Successive Treatment", ret => Targeting.ShouldAoeHeal),
+                    Spell.HealGround("Kolto Bomb", ret => !Tank.HasBuff("Kolto Residue")),
+
+                    //Single Target Healing 
+                    Spell.Heal("Bacta Infusion", 80),
+                    Spell.Heal("Advanced Medical Probe", 80),
+                    Spell.Heal("Medical Probe", 75),
+
+                    //Keep Trauma Probe on Tank 
+                    Spell.HoT("Trauma Probe", 100),
+
+                    //To keep Supercharge buff up; filler heal 
+                    Spell.Heal("Med Shot", onUnit => Tank, 100, ret => Tank != null && Me.InCombat)
+                    );
+            }
+        }
+    }
+}

--- a/DefaultCombat.cs
+++ b/DefaultCombat.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System.Windows;
+using Buddy.BehaviorTree;
+using Buddy.CommonBot;
+using Buddy.Swtor;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+using Targeting = DefaultCombat.Core.Targeting;
+
+namespace DefaultCombat
+{
+	public class DefaultCombat : CombatRoutine
+	{
+		public static bool IsHealer;
+		private static readonly InventoryManagerItem MedPack = new InventoryManagerItem("Medpac", 90);
+		private Composite _combat;
+		private Composite _ooc;
+		private Composite _pull;
+
+        public static bool MovementDisabled
+		{
+			get { return BotMain.CurrentBot.Name == "Combat Bot"; }
+		}
+
+        public static bool Grind
+        {
+            get { return BotMain.CurrentBot.Name == "Grind Bot"; }
+        }
+
+        public override string Name
+		{
+			get { return "DefaultCombat"; }
+		}
+
+		public override Window ConfigWindow
+		{
+			get { return null; }
+		}
+
+		public override CharacterClass Class
+		{
+			get { return BuddyTor.Me.Class; }
+		}
+
+		public override Composite OutOfCombat
+		{
+			get { return _ooc; }
+		}
+
+		public override Composite Pull
+		{
+			get { return _pull; }
+		}
+
+		public override Composite Combat
+		{
+			get { return _combat; }
+		}
+
+		public override void Dispose()
+		{
+		}
+
+		public override void Initialize()
+		{
+			Logger.Write("Level: " + BuddyTor.Me.Level);
+			Logger.Write("Class: " + Class);
+			Logger.Write("Advanced Class: " + BuddyTor.Me.AdvancedClass);
+			Logger.Write("Discipline: " + BuddyTor.Me.Discipline);
+
+			var f = new RotationFactory();
+			var b = f.Build(BuddyTor.Me.Discipline.ToString());
+
+			CombatHotkeys.Initialize();
+
+			if (b == null)
+				b = f.Build(BuddyTor.Me.CharacterClass.ToString());
+
+			Logger.Write("Rotation Selected : " + b.Name);
+
+			if (BuddyTor.Me.IsHealer())
+			{
+				IsHealer = true;
+				Logger.Write("Healing Enabled");
+			}
+
+			_ooc = new Decorator(ret => !BuddyTor.Me.IsDead && !BuddyTor.Me.IsMounted && !CombatHotkeys.PauseRotation,
+				new PrioritySelector(
+					Spell.Buff(BuddyTor.Me.SelfBuffName()),
+					b.Buffs,
+					Rest.HandleRest,
+                    Scavenge.ScavengeCorpse
+					));
+
+			_combat = new Decorator(ret => !CombatHotkeys.PauseRotation,
+				new PrioritySelector(
+					Spell.WaitForCast(),
+					MedPack.UseItem(ret => BuddyTor.Me.HealthPercent <= 30),
+					Targeting.ScanTargets,
+					b.Cooldowns,
+					new Decorator(ret => CombatHotkeys.EnableAoe, b.AreaOfEffect),
+					b.SingleTarget));
+
+			_pull = new Decorator(ret => !CombatHotkeys.PauseRotation && !MovementDisabled || IsHealer && !Grind,
+				_combat
+				);
+		}
+	}
+}

--- a/DefaultCombat.csproj
+++ b/DefaultCombat.csproj
@@ -1,0 +1,166 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{26C92A67-A636-4714-89B9-CB95A8DD463B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DefaultCombat</RootNamespace>
+    <AssemblyName>DefaultCombat</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SccProjectName>Svn</SccProjectName>
+    <SccLocalPath>Svn</SccLocalPath>
+    <SccAuxPath>Svn</SccAuxPath>
+    <SccProvider>SubversionScc</SccProvider>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Buddywing">
+      <HintPath>..\..\Buddywing.exe</HintPath>
+    </Reference>
+    <Reference Include="GreyMagic">
+      <HintPath>..\..\GreyMagic.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Core\LockSelector.cs" />
+    <Compile Include="Core\Movement.cs" />
+    <Compile Include="Core\RotationFactory.cs" />
+    <Compile Include="Core\Spell.cs" />
+    <Compile Include="Core\Targeting.cs" />
+    <Compile Include="Helpers\Extensions.cs" />
+    <Compile Include="Helpers\Global.cs" />
+    <Compile Include="Helpers\CombatHotkeys.cs" />
+    <Compile Include="Helpers\InventoryManager.cs" />
+    <Compile Include="Helpers\Logger.cs" />
+    <Compile Include="Helpers\Rest.cs" />
+    <Compile Include="Helpers\Scavenge.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Routines\Advanced\Assassin\Darkness.cs" />
+    <Compile Include="Routines\Advanced\Assassin\Deception.cs" />
+    <Compile Include="Routines\Advanced\Assassin\Hatred.cs" />
+    <Compile Include="Routines\Advanced\Commando\AssaultSpecialist.cs" />
+    <Compile Include="Routines\Advanced\Commando\CombatMedic.cs" />
+    <Compile Include="Routines\Advanced\Commando\Gunnery.cs" />
+    <Compile Include="Routines\Advanced\Guardian\Defense.cs" />
+    <Compile Include="Routines\Advanced\Guardian\Focus.cs" />
+    <Compile Include="Routines\Advanced\Guardian\Vigilance.cs" />
+    <Compile Include="Routines\Advanced\Gunslinger\DirtyFighting.cs" />
+    <Compile Include="Routines\Advanced\Gunslinger\Saboteur.cs" />
+    <Compile Include="Routines\Advanced\Gunslinger\Sharpshooter.cs" />
+    <Compile Include="Routines\Advanced\Juggernaut\Immortal.cs" />
+    <Compile Include="Routines\Advanced\Juggernaut\Rage.cs" />
+    <Compile Include="Routines\Advanced\Juggernaut\Vengeance.cs" />
+    <Compile Include="Routines\Advanced\Marauder\Annihilation.cs" />
+    <Compile Include="Routines\Advanced\Marauder\Carnage.cs" />
+    <Compile Include="Routines\Advanced\Marauder\Fury.cs" />
+    <Compile Include="Routines\Advanced\Mercenary\Arsenal.cs" />
+    <Compile Include="Routines\Advanced\Mercenary\Bodyguard.cs" />
+    <Compile Include="Routines\Advanced\Mercenary\InnovativeOrdnance.cs" />
+    <Compile Include="Routines\Advanced\Operative\Concealment.cs" />
+    <Compile Include="Routines\Advanced\Operative\Lethality.cs" />
+    <Compile Include="Routines\Advanced\Operative\Medicine.cs" />
+    <Compile Include="Routines\Advanced\PowerTech\AdvancedPrototype.cs" />
+    <Compile Include="Routines\Advanced\PowerTech\Pyrotech.cs" />
+    <Compile Include="Routines\Advanced\PowerTech\ShieldTech.cs" />
+    <Compile Include="Routines\Advanced\Sage\Balance.cs" />
+    <Compile Include="Routines\Advanced\Sage\Seer.cs" />
+    <Compile Include="Routines\Advanced\Sage\Telekinetics.cs" />
+    <Compile Include="Routines\Advanced\Scoundrel\Ruffian.cs" />
+    <Compile Include="Routines\Advanced\Scoundrel\Sawbones.cs" />
+    <Compile Include="Routines\Advanced\Scoundrel\Scrapper.cs" />
+    <Compile Include="Routines\Advanced\Sentinel\Combat.cs" />
+    <Compile Include="Routines\Advanced\Sentinel\Concentration.cs" />
+    <Compile Include="Routines\Advanced\Sentinel\Watchman.cs" />
+    <Compile Include="Routines\Advanced\Shadow\Infiltration.cs" />
+    <Compile Include="Routines\Advanced\Shadow\KeneticCombat.cs" />
+    <Compile Include="Routines\Advanced\Shadow\Serenity.cs" />
+    <Compile Include="Routines\Advanced\Sniper\Engineering.cs" />
+    <Compile Include="Routines\Advanced\Sniper\Marksmanship.cs" />
+    <Compile Include="Routines\Advanced\Sniper\Virulence.cs" />
+    <Compile Include="Routines\Advanced\Sorcerer\Corruption.cs" />
+    <Compile Include="Routines\Advanced\Sorcerer\Lightning.cs" />
+    <Compile Include="Routines\Advanced\Sorcerer\Madness.cs" />
+    <Compile Include="Routines\Advanced\Vanguard\Plasmatech.cs" />
+    <Compile Include="Routines\Advanced\Vanguard\ShieldSpecialist.cs" />
+    <Compile Include="Routines\Advanced\Vanguard\Tactics.cs" />
+    <Compile Include="Routines\Basic\Agent.cs" />
+    <Compile Include="Routines\Basic\BountyHunter.cs" />
+    <Compile Include="Routines\Basic\Consular.cs" />
+    <Compile Include="Routines\Basic\Inquisitor.cs" />
+    <Compile Include="Routines\Basic\Knight.cs" />
+    <Compile Include="Routines\Basic\Smuggler.cs" />
+    <Compile Include="Routines\Basic\Trooper.cs" />
+    <Compile Include="Routines\Basic\Warrior.cs" />
+    <Compile Include="Routines\RotationBase.cs" />
+    <Compile Include="DefaultCombat.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DefaultCombat.sln
+++ b/DefaultCombat.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DefaultCombat", "DefaultCombat.csproj", "{26C92A67-A636-4714-89B9-CB95A8DD463B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Binaries", "Binaries", "{4F7F2320-9D39-481F-A045-E2588CB1A02A}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\contrib\Buddywing.exe = ..\..\contrib\Buddywing.exe
+		..\..\contrib\GreyMagic.dll = ..\..\contrib\GreyMagic.dll
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{45701CBF-6C3F-4EAE-B8EB-76560674E1DB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Debug|x86.ActiveCfg = Debug|x86
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Debug|x86.Build.0 = Debug|x86
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Release|x86.ActiveCfg = Release|x86
+		{26C92A67-A636-4714-89B9-CB95A8DD463B}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,0 +1,382 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Buddy.Swtor;
+using Buddy.Swtor.Objects;
+
+namespace DefaultCombat.Helpers
+{
+	public static class Extensions
+	{
+        public delegate bool TorCharacterPredicateDelegate(TorCharacter torCharacter);
+        public delegate bool TorPlayerPredicateDelegate(TorPlayer torPlayer);
+        public delegate bool TorEffectPredicateDelegate(TorEffect torEffect);
+
+        public static Debuff[] DebuffList =
+		{
+			new Debuff("Crushing Affliction (Force)", 0),
+			new Debuff("Crushing Affliction (All)", 0),
+			new Debuff("Corrosive Slime", 0),
+			new Debuff("Laser", 4)
+		};
+
+		public static string[] DebuffNamesCrowdControl =
+		{
+			"Afraid (Mental)", // from Intimidating Roar / Awe
+			"Blinded (Tech)", // from Flash Grenade / Flash Bang
+			"Lifted (Force)", // from Whirlwind / Force Lift
+			"Sliced", // from Slice Droid
+			"Asleep (Mental)", // from Concussive Round & Mind Maze
+			"Sleeping", // from Sleep Dart & Tranquilizer
+			"Stunned" // from Debilitate / Dirty Kick
+		};
+
+		// This table contains the list of debuff names which prevent us from being shielded...
+		public static string[] DebuffNamesShielded =
+		{
+			"Deionized", // Result of Sorcerer shielding
+			"Force-imbalance" // Result of Sage shielding
+		};
+
+		private static readonly string[] BuffNamesForCoverVariants = {"Crouch", "Cover"};
+
+		private static readonly IEnumerable<ClassTunables> TunablesByClass = new List<ClassTunables>
+		{
+			// Republic
+			new ClassTunables
+			{
+				Class = CharacterClass.Knight,
+				RejuvenateAbilityName = "Introspection",
+				SelfBuffName = "Force Might",
+				IsRejuvenationNeeded = torPlayer => torPlayer.HealthPercent < 70,
+				IsRejuvenationComplete = torPlayer => torPlayer.HealthPercent >= 95,
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+			new ClassTunables
+			{
+				Class = CharacterClass.Consular,
+				RejuvenateAbilityName = "Meditation",
+				SelfBuffName = "Force Valor",
+				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+				IsRejuvenationComplete =
+					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+			new ClassTunables
+			{
+				Class = CharacterClass.Smuggler,
+				RejuvenateAbilityName = "Recuperate",
+				SelfBuffName = "Lucky Shots",
+				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+				IsRejuvenationComplete =
+					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+			new ClassTunables
+			{
+				Class = CharacterClass.Trooper,
+				RejuvenateAbilityName = "Recharge and Reload",
+				SelfBuffName = "Fortification",
+				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+				IsRejuvenationComplete = torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat > 95),
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+
+			// Empire
+			new ClassTunables
+			{
+				Class = CharacterClass.Warrior,
+				RejuvenateAbilityName = "Channel Hatred",
+				SelfBuffName = "Unnatural Might",
+				IsRejuvenationNeeded = torPlayer => torPlayer.HealthPercent < 70,
+				IsRejuvenationComplete = torPlayer => torPlayer.HealthPercent >= 95,
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+			new ClassTunables
+			{
+				Class = CharacterClass.Inquisitor,
+				RejuvenateAbilityName = "Seethe",
+				SelfBuffName = "Mark of Power",
+				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+				IsRejuvenationComplete =
+					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+			new ClassTunables
+			{
+				Class = CharacterClass.Agent,
+				RejuvenateAbilityName = "Recuperate",
+				SelfBuffName = "Coordination",
+				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+				IsRejuvenationComplete =
+					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+				NormalizedResource = torPlayer => torPlayer.ResourceStat
+			},
+			new ClassTunables
+			{
+				Class = CharacterClass.BountyHunter,
+				RejuvenateAbilityName = "Recharge and Reload",
+				SelfBuffName = "Hunter's Boon",
+				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat > 30),
+				IsRejuvenationComplete = torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat <= 5),
+				NormalizedResource = torPlayer => 100.0f - Math.Min(torPlayer.ResourceStat, 100.0f)
+			},
+
+			// Boundary condition --
+			new ClassTunables
+			{
+				Class = CharacterClass.Unknown,
+				RejuvenateAbilityName = "UNDEFINED",
+				SelfBuffName = "UNDEFINED",
+				IsRejuvenationNeeded = torPlayer => false,
+				IsRejuvenationComplete = torPlayer => true,
+				NormalizedResource = torPlayer => 0.0f
+			}
+		};
+
+		// Derived data structure for quick lookup --
+		private static readonly Dictionary<CharacterClass, ClassTunables> TunablesMap =
+			TunablesByClass.ToDictionary(x => x.Class, x => x);
+
+		public static bool HasMyBuff(this TorCharacter u, string aura)
+		{
+			return u.Buffs.Any(a => a.Name == aura && a.CasterGuid == BuddyTor.Me.Guid);
+		}
+
+		public static bool HasMyDebuff(this TorCharacter u, string aura)
+		{
+			return u.Debuffs.Any(a => a.Name == aura && a.CasterGuid == BuddyTor.Me.Guid);
+		}
+
+		public static int BuffCount(this TorCharacter p, string buffName)
+		{
+			return !p.HasMyBuff(buffName)
+				? 0
+				: p.Buffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).GetStacks();
+		}
+
+		public static int DebuffCount(this TorCharacter p, string buffName)
+		{
+			return !p.HasMyDebuff(buffName)
+				? 0
+				: p.Debuffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).GetStacks();
+		}
+
+		public static double BuffTimeLeft(this TorCharacter p, string buffName)
+		{
+			return !p.HasMyBuff(buffName)
+				? 0
+				: p.Buffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).TimeLeft.TotalSeconds;
+		}
+
+		public static double DebuffTimeLeft(this TorCharacter p, string buffName)
+		{
+			return !p.HasMyDebuff(buffName)
+				? 0
+				: p.Debuffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).TimeLeft.TotalSeconds;
+		}
+
+		public static bool HasDebuffCount(this TorCharacter p, string debuff, int stacks)
+		{
+			return p.HasDebuff(debuff) && p.Debuffs.Any(d => d.Name.Contains(debuff) && d.GetStacks() >= stacks);
+		}
+
+		public static bool NeedsCleanse(this TorCharacter p)
+		{
+			foreach (var d in DebuffList)
+			{
+				if (d.Stacks == 0 && p.HasDebuff(d.Name))
+					return true;
+
+				if (d.Stacks > 0 && p.HasDebuffCount(d.Name, d.Stacks))
+					return true;
+			}
+			return false;
+        }
+
+
+public static IEnumerable<TorCharacter> PartyMembers(this TorPlayer torPlayer, bool includeCompanions = true, TorCharacterPredicateDelegate memberQualifier = null)
+        {
+            memberQualifier = memberQualifier ?? (c => true);   // resolve playerQualifier to something sane
+
+            IEnumerable<TorCharacter> partyMembers = torPlayer.PartyPlayers();
+
+            if (includeCompanions)
+            { partyMembers = partyMembers.Concat(torPlayer.PartyCompanions()); }
+
+            return (partyMembers.Where(c => memberQualifier(c)));
+        }
+
+        public static bool IsPartyRoleTank(this TorCharacter torCharacter)
+        {
+            Global.PartyRole role = torCharacter.PartyRole();
+            return ((role == Global.PartyRole.MeleeTank) || (role == Global.PartyRole.RangedTank));
+        }
+
+        public static IEnumerable<TorNpc> PartyCompanions(this TorPlayer torPlayer, TorCharacterPredicateDelegate companionQualifier = null)
+        {
+            // Extension methods guarantee the 'this' argument is never null, so no need to check a contract here
+
+            companionQualifier = companionQualifier ?? (ctx => true);       // resolve playerQualifier to something sane
+
+            return (torPlayer.PartyPlayers(p => p.IsCompanionInUse() && companionQualifier(p.Companion)).Select(p => p.Companion));
+        }
+
+        public static Global.PartyRole PartyRole(this TorCharacter torCharacter)
+        {
+            //Idk if this was working anyway.
+            return Global.PartyRole.RangedDPS;
+        }
+
+        public static bool IsCompanionInUse(this TorPlayer torPlayer)
+        {
+            // Extension methods guarantee the 'this' argument is never null, so no need to check a contract here
+            return ((torPlayer.CompanionUnlocked > 0) && (torPlayer.Companion != null));
+        }
+
+        public static IEnumerable<TorPlayer> PartyPlayers(this TorPlayer torPlayer, TorPlayerPredicateDelegate playerQualifier = null)
+        {
+            playerQualifier = playerQualifier ?? (ctx => true);       // resolve playerQualifier to something sane
+
+            ulong playerGroupId = torPlayer.GroupId;
+
+            // If we're solo, only have the torPlayer on the list...
+            // We can't build this list using the 'normal' query, as all solo players have the common GroupId of zero.
+            // We don't want a list of 'solo' players (what the normal query would do), we want a list with only the solo torPlayer on it.
+            if (playerGroupId == 0)
+            { return (ObjectManager.GetObjects<TorPlayer>().Where(p => (p == BuddyTor.Me) && playerQualifier(p))); }
+
+            // NB: IsInParty() is implemented in terms of PartyPlayers().  Be careful not to implement this method in terms of
+            // IsInParty(); otherwise, infinite recursive descent will occur.
+            return (ObjectManager.GetObjects<TorPlayer>().Where(p => !p.IsDeleted && playerQualifier(p) && (p.GroupId == playerGroupId)));
+        }
+
+        public static bool IsCrowdControlled(this TorCharacter torCharacter)
+		{
+			return torCharacter.Debuffs.FirstOrDefault(d => DebuffNamesCrowdControl.Contains(d.Name)) != null;
+		}
+
+		public static int GetStacks(this TorEffect t)
+		{
+			var result = 0;
+			try
+			{
+				result = t.Stacks;
+			}
+			catch
+			{
+				result = 1;
+			}
+			return result;
+		}
+
+		public static bool IsValidTarget(this TorCharacter c)
+		{
+            try
+            {
+                return c != null && !c.IsDeleted && c.InCombat && c.IsHostile && !c.IsDead && !c.IsStunned && !c.IsCrowdControlled();
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+		public static bool BossOrGreater(this TorCharacter unit)
+		{
+			if (unit != null) if (unit.Toughness >= CombatToughness.Boss1) return true;
+			return false;
+		}
+
+		public static bool StrongOrGreater(this TorCharacter unit)
+		{
+			if (unit != null) if (unit.Toughness >= CombatToughness.Strong) return true;
+			return false;
+		}
+
+		public static bool IsHealer(this TorPlayer p)
+		{
+			var result = false;
+			switch (p.Discipline)
+			{
+				case CharacterDiscipline.CombatMedic:
+					result = true;
+					break;
+				case CharacterDiscipline.Bodyguard:
+					result = true;
+					break;
+				case CharacterDiscipline.Medicine:
+					result = true;
+					break;
+				case CharacterDiscipline.Seer:
+					result = true;
+					break;
+				case CharacterDiscipline.Sawbones:
+					result = true;
+					break;
+				case CharacterDiscipline.Corruption:
+					result = true;
+					break;
+			}
+			return result;
+		}
+
+		public static bool IsInCover(this TorCharacter torCharacter)
+		{
+			return torCharacter.Buffs.Any(b => BuffNamesForCoverVariants.Contains(b.Name));
+		}
+
+		public static bool IsBehind(this TorCharacter torCharacter, TorCharacter target)
+		{
+			return Math.Abs(BuddyTor.Me.Heading - target.Heading) <= 150; // && CurrentTarget.IsInRange(0.35f)
+		}
+
+		public static float ResourcePercent(this TorPlayer torPlayer)
+		{
+			return TunablesMap[torPlayer.Class].NormalizedResource(torPlayer);
+		}
+
+		public static string RejuvenateAbilityName(this TorPlayer torPlayer)
+		{
+			return TunablesMap[torPlayer.Class].RejuvenateAbilityName;
+		}
+
+		public static string SelfBuffName(this TorPlayer torPlayer)
+		{
+			return TunablesMap[torPlayer.Class].SelfBuffName;
+		}
+
+		private delegate bool PredicateDelegate(TorPlayer torPlayer);
+
+		private delegate float NormalizedResourceDelegate(TorPlayer torPlayer);
+
+		private class ClassTunables
+		{
+			/// <summary>
+			///     The <c>CharacterClass</c> to which this set of <c>ClassTunables</c> applies.
+			/// </summary>
+			public CharacterClass Class = CharacterClass.Unknown;
+
+			public PredicateDelegate IsRejuvenationComplete = torPlayer => true;
+			public PredicateDelegate IsRejuvenationNeeded = torPlayer => false;
+			public NormalizedResourceDelegate NormalizedResource = torPlayer => 0.0f;
+			public string RejuvenateAbilityName = "UNDEFINED";
+			public string SelfBuffName = "UNDEFINED";
+		}
+	}
+
+	public class Debuff
+	{
+		public string Name;
+		public int Stacks;
+
+		public Debuff(string name, int stacks)
+		{
+			Name = name;
+			Stacks = stacks;
+		}
+	}
+}

--- a/Global.cs
+++ b/Global.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+namespace DefaultCombat.Helpers
+{
+    public class Global
+    {
+        public const int EnergyMinimum = 65;
+        public const int CellMinimum = 8;
+        public enum PartyRole
+        {
+            MeleeTank,
+            RangedTank,
+            MeleeDPS,
+            RangedDPS,
+            Healer
+        }
+
+    }
+	public class Distance
+	{
+		public const float Melee = 0.4f;
+		public const float MeleeAoE = 0.8f;
+		public const float Ranged = 2.8f;
+        public const float HealAoe = 1.2f;
+	}
+
+
+
+    public class Health
+	{
+		public const int Max = 95;
+		public const int Shield = 90;
+		public const int High = 85;
+		public const int Mid = 50;
+		public const int Low = 35;
+		public const int Critical = 15;
+		public const int OffHealThreshold = 40;
+	}
+}

--- a/Gunnery.cs
+++ b/Gunnery.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+	internal class Gunnery : RotationBase
+	{
+		public override string Name
+		{
+			get { return "Commando Gunnery"; }
+		}
+
+		public override Composite Buffs
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Armor-piercing Cell"),
+					Spell.Buff("Fortification")
+					);
+			}
+		}
+
+		public override Composite Cooldowns
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Tenacity"),
+					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
+					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+					Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 40),
+					Spell.Buff("Supercharged Cell", ret => Me.BuffCount("Supercharge") == 10),
+					Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60)
+					);
+			}
+		}
+
+		public override Composite SingleTarget
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Cast("Hammer Shot", ret => Me.ResourcePercent() < 60),
+
+					//Movement
+					CombatMovement.CloseDistance(Distance.Ranged),
+
+					//Rotation
+					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled),
+					Spell.Cast("Boltstorm", ret => Me.HasBuff("Curtain of Fire") && Me.Level >= 57),
+					Spell.Cast("Full Auto", ret => Me.HasBuff("Curtain of Fire") && Me.Level < 57),
+					Spell.Cast("Demolition Round", ret => Me.CurrentTarget.HasDebuff("Gravity Vortex")),
+					Spell.Cast("Electro Net"),
+					Spell.Cast("Vortex Bolt"),
+					Spell.Cast("High Impact Bolt", ret => Me.BuffCount("Charged Barrel") == 5),
+					Spell.Cast("Grav Round")
+					);
+			}
+		}
+
+		public override Composite AreaOfEffect
+		{
+			get
+			{
+				return new Decorator(ret => Targeting.ShouldAoe,
+					new PrioritySelector(
+						Spell.Cast("Tech Override"),
+						Spell.CastOnGround("Mortar Volley"),
+						Spell.Cast("Plasma Grenade", ret => Me.ResourceStat >= 90 && Me.HasBuff("Tech Override")),
+						Spell.Cast("Pulse Cannon", ret => Me.CurrentTarget.Distance <= 1f),
+						Spell.CastOnGround("Hail of Bolts", ret => Me.ResourceStat >= 90)
+						));
+			}
+		}
+	}
+}

--- a/InventoryManager.cs
+++ b/InventoryManager.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System.Diagnostics;
+using Buddy.BehaviorTree;
+using Buddy.Common;
+using Buddy.Swtor;
+using log4net;
+
+namespace DefaultCombat.Helpers
+{
+	public class InventoryManagerItem
+	{
+		public delegate T Selection<out T>(object context);
+
+		private readonly Stopwatch _timer;
+		private readonly ILog _log = Log.Get();
+		public int CoolDown;
+		public string ItemName;
+
+		public InventoryManagerItem(string name, int cd)
+		{
+			ItemName = name;
+			CoolDown = cd;
+			_timer = new Stopwatch();
+			_log.Info(name + "  Created!");
+		}
+
+		public Composite UseItem(Selection<bool> reqs = null)
+		{
+			return new Decorator(ret => reqs == null || reqs(ret),
+				new Action(delegate
+				{
+					if (_timer.IsRunning && _timer.Elapsed.TotalSeconds < CoolDown)
+						return RunStatus.Failure;
+
+					if (!_timer.IsRunning)
+						_timer.Start();
+
+					foreach (var o in BuddyTor.Me.InventoryEquipment)
+					{
+						if (o.Name.Contains(ItemName))
+						{
+							o.Use();
+							o.Interact();
+							_timer.Stop();
+							_timer.Reset();
+							_timer.Start();
+							return RunStatus.Success;
+						}
+					}
+					return RunStatus.Failure;
+				}));
+		}
+	}
+}

--- a/LockSelector.cs
+++ b/LockSelector.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using Buddy.Swtor;
+
+namespace DefaultCombat.Core
+{
+	// Use this type sparingly - nesting locks will be handled by the memory library implicitly:
+	// acquiring a single lock for the entire duration of a tick will have the same effect as acquiring 20
+	// locks by using LockSelector in various locations. More locking does therefore not guarantee "more" 
+	// consistency between the game's state. If you decide to use this type, use it in the outermost part of your logic,
+	// so that all children of the selector will run inside the lock, but if possible, refrain from replacing every
+	// single PrioritySelector with a LockSelector - it has proven to be detriment to performance for no tangible gains.
+	public class LockSelector : PrioritySelector
+	{
+		public LockSelector(params Composite[] children)
+			: base(children)
+		{
+		}
+
+		public override RunStatus Tick(object context)
+		{
+			using (BuddyTor.Memory.AcquireFrame())
+			{
+				return base.Tick(context);
+			}
+		}
+	}
+}

--- a/Logger.cs
+++ b/Logger.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System.Windows.Media;
+using Buddy.Common;
+
+namespace DefaultCombat
+{
+	public static class Logger
+	{
+		public static void Write(string message)
+		{
+			Write(Colors.Green, message);
+		}
+
+		public static void Write(string message, params object[] args)
+		{
+			Write(Colors.Green, message, args);
+		}
+
+		public static void Write(Color clr, string message, params object[] args)
+		{
+			Logging.Write(clr, "[DefaultCombat] " + message, args);
+		}
+	}
+}

--- a/Movement.cs
+++ b/Movement.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using Buddy.CommonBot;
+using Buddy.Navigation;
+using Buddy.Swtor;
+
+namespace DefaultCombat.Core
+{
+	public class CombatMovement
+	{
+		public static Composite CloseDistance(float range)
+		{
+			return new Decorator(ret => !DefaultCombat.MovementDisabled && BuddyTor.Me.CurrentTarget != null,
+				new PrioritySelector(
+					new Decorator(ret => BuddyTor.Me.CurrentTarget.Distance < range,
+						new Action(delegate
+						{
+							Navigator.MovementProvider.StopMovement();
+							return RunStatus.Failure;
+						})),
+					new Decorator(ret => BuddyTor.Me.CurrentTarget.Distance >= range,
+						CommonBehaviors.MoveAndStop(location => BuddyTor.Me.CurrentTarget.Position, range, true)),
+					new Action(delegate { return RunStatus.Failure; })));
+		}
+	}
+}

--- a/Rest.cs
+++ b/Rest.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Buddy.BehaviorTree;
+using Buddy.CommonBot;
+using Buddy.Swtor;
+using Buddy.Swtor.Objects;
+using DefaultCombat.Core;
+using Action = Buddy.BehaviorTree.Action;
+
+namespace DefaultCombat.Helpers
+{
+	public static class Rest
+	{
+
+        private static TorPlayer Me
+		{
+			get { return BuddyTor.Me; }
+		}
+
+		private static Composite ReviveCompanion
+		{
+			get
+			{
+				return new PrioritySelector(
+					new Decorator(ret => Me.Companion != null && Me.Companion.IsDead,
+						new PrioritySelector(
+							Spell.WaitForCast(),
+							CommonBehaviors.MoveAndStop(location => Me.Companion.Position, 0.2f, true),
+							Spell.Cast("Revive Companion", on => Me.Companion, when => Me.Companion.Distance <= 0.3f)
+							))
+					);
+			}
+		}
+
+		private static Composite Rejuvenate
+		{
+			get
+			{
+				using (BuddyTor.Memory.AcquireFrame())
+				{
+					return new Action(delegate
+					{
+						if (NeedRest())
+						{
+							if (BuddyTor.Me.IsMoving) Input.MoveStopAll();
+							while (KeepResting())
+							{
+								if (!Me.IsCasting)
+									AbilityManager.Cast(Me.RejuvenateAbilityName(), Me);
+
+								Thread.Sleep(100);
+							}
+                            Movement.Move(Buddy.Swtor.MovementDirection.Forward, System.TimeSpan.FromMilliseconds(1));
+                            return RunStatus.Success;
+                        }
+
+						return RunStatus.Failure;
+					});
+				}
+			}
+		}
+
+		public static Composite HandleRest
+		{
+			get
+			{
+				return new PrioritySelector(
+					ReviveCompanion,
+					Rejuvenate
+					);
+			}
+		}
+
+
+
+		public static int NormalizedResource()
+		{
+			if (Me.AdvancedClass == AdvancedClass.None)
+			{
+				switch (Me.Class)
+				{
+					//Add cases needed for reverse basic classes
+					case CharacterClass.BountyHunter:
+						return 100 - (int) Me.ResourcePercent();
+					case CharacterClass.Warrior:
+						return 100;
+					case CharacterClass.Knight:
+						return 100;
+					default:
+						return (int) Me.ResourcePercent();
+				}
+			}
+			switch (Me.AdvancedClass)
+			{
+				//Add cases needed for reverse Advance classes
+				case AdvancedClass.Mercenary:
+					return 100 - (int) Me.ResourcePercent();
+				case AdvancedClass.Powertech:
+					return 100 - (int) Me.ResourcePercent();
+				case AdvancedClass.Juggernaut:
+					return 100;
+				case AdvancedClass.Marauder:
+					return 100;
+				case AdvancedClass.Guardian:
+					return 100;
+				case AdvancedClass.Sentinel:
+					return 100;
+				default:
+					return (int) Me.ResourcePercent();
+			}
+		}
+
+        public static bool NeedRest()
+        {
+            var resource = NormalizedResource();
+            return !DefaultCombat.MovementDisabled && !Me.InCombat && (resource < 50 || Me.HealthPercent < 50
+                                                                       || (Me.Companion != null && !Me.Companion.IsDead && Me.Companion.HealthPercent < 50));
+        }
+
+		public static bool KeepResting()
+		{
+			var resource = NormalizedResource();
+			return !DefaultCombat.MovementDisabled && !Me.InCombat && (resource < 100 || Me.HealthPercent < 100
+																	   || (Me.Companion != null && !Me.Companion.IsDead && Me.Companion.HealthPercent < 100));
+		}
+	}
+}

--- a/RotationFactory.cs
+++ b/RotationFactory.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System;
+using System.Reflection;
+using Buddy.Swtor;
+using DefaultCombat.Routines;
+
+namespace DefaultCombat.Core
+{
+	public class RotationFactory
+	{
+		public RotationBase Build(string name)
+		{
+			//Set the basic class as the rotation if char has no advanced class
+			if (BuddyTor.Me.AdvancedClass == AdvancedClass.None)
+			{
+				name = BuddyTor.Me.CharacterClass.ToString();
+			}
+
+			if (name == "Rage" && BuddyTor.Me.AdvancedClass == AdvancedClass.Marauder)
+			{
+				name = "Fury";
+			}
+
+			if (name == "Focus" && BuddyTor.Me.AdvancedClass == AdvancedClass.Sentinel)
+			{
+				name = "Concentration";
+			}
+
+			if (name == "DirtyFighting" && BuddyTor.Me.AdvancedClass == AdvancedClass.Scoundrel)
+			{
+				name = "Ruffian";
+			}
+
+			if (name == "Balance" && BuddyTor.Me.AdvancedClass == AdvancedClass.Shadow)
+			{
+				name = "Serenity";
+			}
+
+			if (name == "CombatMedic" && BuddyTor.Me.AdvancedClass == AdvancedClass.Mercenary)
+			{
+				name = "Bodyguard";
+			}
+
+			if (name == "Firebug" && BuddyTor.Me.AdvancedClass == AdvancedClass.Powertech)
+			{
+				name = "Pyrotech";
+			}
+
+			var ns = "DefaultCombat.Routines";
+			var assembly = Assembly.GetExecutingAssembly();
+			var type = assembly.GetType(ns + "." + name);
+			var instance = Activator.CreateInstance(type);
+			return (RotationBase) instance;
+		}
+	}
+}

--- a/Ruffian.cs
+++ b/Ruffian.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+	internal class Ruffian : RotationBase
+	{
+		public override string Name
+		{
+			get { return "Scoundrel Ruffian"; }
+		}
+
+		public override Composite Buffs
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Lucky Shots"),
+					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+					);
+			}
+		}
+
+		public override Composite Cooldowns
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 45),
+					Spell.Buff("Pugnacity", ret => !Me.HasBuff("Upper Hand") && Me.InCombat),
+					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
+					Spell.Buff("Dodge", ret => Me.HealthPercent <= 50)
+					);
+			}
+		}
+
+		public override Composite SingleTarget
+		{
+			get
+			{
+				return new PrioritySelector(
+					//Movement
+					CombatMovement.CloseDistance(Distance.Melee),
+
+					//Low Energy
+					new Decorator(ret => Me.EnergyPercent < 60,
+						new PrioritySelector(
+							Spell.Cast("Flurry of Bolts")
+							)),
+
+					//Rotation
+					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && Me.CurrentTarget.Distance <= 1f),
+					Spell.Cast("Brutal Shots",
+						ret =>
+							Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Bleeding (Tech)") &&
+							Me.HasBuff("Upper Hand")),
+					Spell.Cast("Sanguinary Shot",
+						ret => Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Bleeding (Tech)")),
+					Spell.DoT("Vital Shot", "Vital Shot"),
+					Spell.DoT("Shrap Bomb", "Bleeding (Tech)"),
+					Spell.Cast("Blaster Whip", ret => Me.BuffCount("Upper Hand") < 2 || Me.BuffTimeLeft("Upper Hand") < 6),
+					Spell.Cast("Point Blank Shot", ret => Me.Level >= 57),
+					Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget) && Me.Level < 57),
+					Spell.Cast("Quick Shot")
+					);
+			}
+		}
+
+		public override Composite AreaOfEffect
+		{
+			get
+			{
+				return new Decorator(ret => Targeting.ShouldAoe,
+					new PrioritySelector(
+						Spell.DoT("Shrap Bomb", "Bleeding (Tech)"),
+						Spell.Cast("Thermal Grenade"),
+						Spell.Cast("Blaster Volley", ret => Me.HasBuff("Upper Hand"))
+						));
+			}
+		}
+	}
+}

--- a/Sawbones.cs
+++ b/Sawbones.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH 
+// See the file LICENSE for the source code's detailed license 
+
+using Buddy.BehaviorTree; 
+using DefaultCombat.Core; 
+using DefaultCombat.Helpers; 
+
+namespace DefaultCombat.Routines 
+{ 
+    public class Sawbones : RotationBase 
+    { 
+        public override string Name 
+        { 
+            get { return "Scoundrel Sawbones"; } 
+        } 
+
+        public override Composite Buffs 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    Spell.Buff("Lucky Shots"), 
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !Rest.NeedRest()) 
+                    ); 
+            } 
+        } 
+
+        public override Composite Cooldowns 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 20), 
+                    Spell.Buff("Pugnacity", ret => Me.EnergyPercent <= 70 && Me.BuffCount("Upper Hand") < 3), 
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75), 
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 50), 
+                    Spell.Buff("Escape", ret => Me.IsCrowdControlled()) 
+                    ); 
+            } 
+        } 
+
+        //DPS 
+        public override Composite SingleTarget 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && Me.CurrentTarget.Distance <= 1f), 
+                    Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget)), 
+                    Spell.Cast("Blaster Whip"), 
+                    Spell.Cast("Vital Shot", ret => !Me.CurrentTarget.HasDebuff("Vital Shot")), 
+                    Spell.Cast("Charged Burst", ret => Me.EnergyPercent >= 70), 
+                    Spell.Cast("Quick Shot", ret => Me.EnergyPercent >= 70), 
+                    Spell.Cast("Flurry of Bolts") 
+                    ); 
+            } 
+        } 
+
+        //Healing 
+        public override Composite AreaOfEffect 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    Spell.HealGround("Kolto Waves", ret => Targeting.ShouldAoeHeal), 
+                    Spell.Heal("Kolto Cloud", on => Tank, 80, ret => Tank != null && Targeting.ShouldAoeHeal), 
+                    Spell.Heal("Emergency Medpac", 90, ret => emergencyMedpac()), 
+                    Spell.Heal("Slow-release Medpac", on => Tank, 100, ret => Tank != null && tankSlowMedpac()), 
+                    Spell.Heal("Kolto Pack", 80, ret => Me.BuffCount("Upper Hand") >= 2 && Me.EnergyPercent >= 60 && !HealTarget.HasMyBuff("Kolto Pack")), 
+                    Spell.Heal("Underworld Medicine", 80), 
+                    Spell.Cleanse("Triage"), 
+                    Spell.Heal("Slow-release Medpac", 90, ret => targetSlowMedpac()), 
+                    Spell.Heal("Diagnostic Scan", 95) 
+                    ); 
+            } 
+        } 
+
+        public static bool tankSlowMedpac() 
+        { 
+            if (Targeting.Tank.BuffCount("Slow-release Medpac") < 2) 
+                return true; 
+            if (Targeting.Tank.BuffTimeLeft("Slow-release Medpac") < 3) 
+                return true; 
+            return false; 
+        } 
+
+        public static bool targetSlowMedpac() 
+        { 
+            if (Targeting.HealTarget.BuffCount("Slow-release Medpac") < 2) 
+                return true; 
+            if (Targeting.HealTarget.BuffTimeLeft("Slow-release Medpac") < 3) 
+                return true; 
+            return false; 
+        } 
+
+        public static bool emergencyMedpac() 
+        { 
+            if (Targeting.HealTarget.BuffTimeLeft("Slow-release Medpac") > 6) 
+                return false; 
+            if (Targeting.HealTarget.BuffCount("Slow-release Medpac") < 2) 
+                return false; 
+            if (Me.BuffCount("Upper Hand") < 2) 
+                return false; 
+            return true; 
+        } 
+    } 
+}  

--- a/Scavenge.cs
+++ b/Scavenge.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Buddy.BehaviorTree;
+using Buddy.Common;
+using Buddy.CommonBot;
+using Buddy.Swtor;
+using Buddy.Swtor.Objects;
+using Buddy.Navigation;
+using Buddywing;
+using Buddy.CommonBot.Settings;
+using DefaultCombat.Core;
+
+using Action = Buddy.BehaviorTree.Action;
+
+namespace DefaultCombat.Helpers
+{
+
+    //This shit comes from Joe's
+    class Scavenge
+    {
+        private static TorPlayer Me { get { return BuddyTor.Me; } }
+
+        private static bool HasScav { get { return Me.ProfessionInfos.Any(p => p.Name.Contains("Scavenging")); } }
+        private static bool HasBio { get { return Me.ProfessionInfos.Any(p => p.Name.Contains("Bioanalysis")); } }
+
+
+        public static bool CanHarvestCorpse(TorNpc unit)
+        {
+            ulong SkillReq = Math.Max(unit.Level - 3, 0) * 8;
+            if (unit != null) if (!unit.IsDeleted) if (unit.IsDead && unit.Distance <= 4.0f 
+                && ((HasBio && unit.CreatureType == Buddy.Swtor.CreatureType.Creature && PISkill("Bioanalysis") >= SkillReq) || (HasScav && unit.CreatureType == Buddy.Swtor.CreatureType.Droid && PISkill("Scavenging") >= SkillReq))
+                && StrongOrGreater(unit) && !unit.IsFriendly) if (!Buddy.CommonBot.Blacklist.Contains(unit.Guid)) 
+                    return true;
+
+            return false;
+        }
+
+        public static ulong PISkill(string Skill)
+        {
+            foreach (Buddy.Swtor.Objects.Components.ProfessionInfo pi in BuddyTor.Me.ProfessionInfos) if (pi.Name.Contains(Skill)) return (ulong)pi.CurrentLevel;
+            return 0;
+        }
+
+        public static bool StrongOrGreater(TorCharacter unit)
+        {
+            if (unit != null) if (unit.Toughness == CombatToughness.Strong || unit.Toughness == CombatToughness.Boss1 || unit.Toughness == CombatToughness.Boss2 || unit.Toughness == CombatToughness.Player) return true;
+            return false;
+        }
+
+        public static TorCharacter ScavUnit
+        {
+            get
+            {
+                return ObjectManager.GetObjects<TorNpc>().Where(p => CanHarvestCorpse(p)).FirstOrDefault();
+            }
+        }
+
+        public static Composite ScavengeCorpse
+        {
+            get
+            {
+                return new PrioritySelector(
+                   new Decorator(ret => ScavUnit != null,
+                        new PrioritySelector(
+                            Spell.WaitForCast(),
+                            CommonBehaviors.MoveAndStop(location => ScavUnit.Position, 0.2f, true),
+                            new Action(ret => ScavUnit.Interact())
+                            ))
+                   );
+            }
+        }
+    }
+}

--- a/Scrapper.cs
+++ b/Scrapper.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+	public class Scrapper : RotationBase
+	{
+		public override string Name
+		{
+			get { return "Scoundrel Scrapper"; }
+		}
+
+		public override Composite Buffs
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Lucky Shots"),
+					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !Rest.NeedRest())
+					);
+			}
+		}
+
+		public override Composite Cooldowns
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 45),
+					Spell.Buff("Pugnacity", ret => Me.HasBuff("Upper Hand")),
+					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
+					Spell.Buff("Dodge", ret => Me.HealthPercent <= 50)
+					);
+			}
+		}
+
+		public override Composite SingleTarget
+		{
+			get
+			{
+				return new PrioritySelector(
+					//Movement
+					CombatMovement.CloseDistance(Distance.Melee),
+
+					//Low Energy
+					new Decorator(ret => Me.EnergyPercent < 60,
+						new PrioritySelector(
+							Spell.Cast("Flurry of Bolts")
+							)),
+
+					//Rotation
+					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting),
+					Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget)),
+					Spell.Cast("Sucker Punch", ret => Me.HasBuff("Upper Hand") && Me.CurrentTarget.HasDebuff("Vital Shot")),
+					Spell.DoT("Vital Shot", "Vital Shot"),
+					Spell.Cast("Blood Boiler"),
+					Spell.Cast("Bludgeon", ret => Me.Level >= 41),
+					Spell.Cast("Blaster Whip", ret => Me.Level < 41),
+					Spell.Cast("Quick Shot", ret => Me.EnergyPercent >= 75)
+					);
+			}
+		}
+
+		public override Composite AreaOfEffect
+		{
+			get
+			{
+				return new Decorator(ret => Targeting.ShouldAoe,
+					new PrioritySelector(
+						Spell.Cast("Thermal Grenade"),
+						Spell.Cast("Blaster Volley", ret => Me.HasBuff("Upper Hand") && Me.CurrentTarget.Distance <= 10f))
+					);
+			}
+		}
+	}
+}

--- a/Seer.cs
+++ b/Seer.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH 
+// See the file LICENSE for the source code's detailed license 
+
+using Buddy.BehaviorTree; 
+using DefaultCombat.Core; 
+using DefaultCombat.Helpers; 
+
+namespace DefaultCombat.Routines 
+{ 
+    internal class Seer : RotationBase 
+    { 
+        public override string Name 
+        { 
+            get { return "Sage Seer"; } 
+        } 
+
+        public override Composite Buffs 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    Spell.Buff("Force Valor") 
+                    ); 
+            } 
+        } 
+
+        public override Composite Cooldowns 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    Spell.Buff("Force Potency", ret => Targeting.ShouldAoeHeal), 
+                    Spell.Buff("Mental Alacrity", ret => Targeting.ShouldAoeHeal), 
+                    Spell.Buff("Vindicate", ret => NeedForce()), 
+                    Spell.Buff("Force Mend", ret => Me.HealthPercent <= 75) 
+                    ); 
+            } 
+        } 
+
+        public override Composite SingleTarget 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    //Movement 
+                    CombatMovement.CloseDistance(Distance.Ranged), 
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled), 
+                    Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled), 
+                    Spell.Cast("Forcequake", ret => Targeting.ShouldAoe), 
+                    Spell.Cast("Mind Crush"), 
+                    Spell.DoT("Weaken Mind", "Weaken Mind"), 
+                    Spell.Cast("Project"), 
+                    Spell.Cast("Telekinetic Throw"), 
+                    Spell.Cast("Disturbance") 
+                    ); 
+            } 
+        } 
+
+        public override Composite AreaOfEffect 
+        { 
+            get 
+            { 
+                return new PrioritySelector( 
+                    //Cleanse if needed 
+                    Spell.Cleanse("Restoration"), 
+
+                    //Emergency Heal (Insta-cast) 
+                    Spell.Heal("Benevolence", 80, ret => Me.HasBuff("Altruism")), 
+
+                    //Aoe Heal 
+                    Spell.HealGround("Salvation", ret => Targeting.ShouldAoeHeal), 
+
+                    //Single Target Healing 
+                    Spell.Heal("Healing Trance", 80), 
+                    Spell.HoT("Force Armor", 90, ret => HealTarget != null && !HealTarget.HasDebuff("Force-imbalance")), 
+
+                    //Buff Tank 
+                    Spell.HoT("Force Armor", onUnit => Tank, 100, ret => Tank != null && Tank.InCombat && !Tank.HasDebuff("Force-imbalance")), 
+                    Spell.Heal("Wandering Mend", onUnit => Tank, 100, 
+                        ret => Tank != null && Tank.InCombat && Me.BuffCount("Wandering Mend Charges") <= 1), 
+
+                    //Use Force Bending 
+                    new Decorator(ret => Me.HasBuff("Conveyance"), 
+                        new PrioritySelector( 
+                            Spell.Heal("Healing Trance", 90), 
+                            Spell.Heal("Deliverance", 50) 
+                            )), 
+
+                    //Build Force Bending 
+                    Spell.HoT("Rejuvenate", 80), 
+                    Spell.HoT("Rejuvenate", onUnit => Tank, 100, ret => Tank != null && Tank.InCombat), 
+
+                    //Single Target Healing                   
+                    Spell.Heal("Benevolence", 35), 
+                    Spell.Heal("Deliverance", 80) 
+                    ); 
+            } 
+        } 
+
+        private bool NeedForce() 
+        { 
+            if (Me.ForcePercent <= 20) 
+                return true; 
+            if (Me.HasBuff("Resplendence") && Me.ForcePercent < 80 && !Me.HasBuff("Amnesty")) 
+                return true; 
+            return false; 
+        } 
+    } 
+}  

--- a/Spell.cs
+++ b/Spell.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Timers;
+using Buddy.BehaviorTree;
+using Buddy.Common.Math;
+using Buddy.CommonBot;
+using Buddy.Swtor;
+using Buddy.Swtor.Objects;
+using DefaultCombat.Helpers;
+using Action = Buddy.BehaviorTree.Action;
+
+namespace DefaultCombat.Core
+{
+	public static class Spell
+	{
+		public delegate T Selection<out T>(object context);
+
+		public delegate TorCharacter UnitSelectionDelegate(object context);
+
+		public static List<ExpiringItem> BlackListedSpells = new List<ExpiringItem>();
+
+		private static TorPlayer Me
+		{
+			get { return BuddyTor.Me; }
+		}
+
+		public static Composite BuffBehavior
+		{
+			get
+			{
+				return new PrioritySelector(
+					Buff("Sprint"),
+					Buff(Me.SelfBuffName()),
+					Rest.HandleRest);
+			}
+		}
+
+		public static Composite WaitForCast()
+		{
+			return new Decorator(ret => BuddyTor.Me.IsCasting,
+				new Action(ret => RunStatus.Success));
+		}
+
+		#region Buff
+
+		public static Composite Buff(string spell, Selection<bool> reqs = null)
+		{
+			return
+				new Decorator(
+					ret => (reqs == null || reqs(ret)) && !Me.HasBuff(spell),
+					Cast(spell, ret => Me, ret => true));
+		}
+
+		#endregion
+
+		#region Cast
+
+		public static Composite Cast(string spell, Selection<bool> reqs = null)
+		{
+			return Cast(spell, ret => Me.CurrentTarget, reqs);
+		}
+
+		public static Composite Cast(string spell, UnitSelectionDelegate onUnit, Selection<bool> reqs = null)
+		{
+            return
+                new Decorator(
+                    ret =>
+                        onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) &&
+                        AbilityManager.CanCast(spell, onUnit(ret)),
+                    new PrioritySelector(
+                        new Action(delegate
+                        {
+                        //added current target health percent check
+                        Logger.Write(">> Casting <<   " + spell);
+                      //  Logger.Write(Targeting.Tank.ToString());
+                      //  Logger.Write(Me.PartyMembers(false).ToList() + "Members");
+                         //   if (DefaultCombat.IsHealer)
+                         //   {
+                            //    Logger.Write(" Health" + Me.CurrentTarget.Health + " TGTPCT" + Targeting.HealTarget.HealthPercent + " MXHLTH" + Targeting.HealTarget.HealthMax);
+                         //   }
+                            return RunStatus.Failure;
+						}),
+						new Action(ret => AbilityManager.Cast(spell, onUnit(ret))))
+					);
+		}
+
+		public static Composite CastOnGround(string spell, Selection<bool> reqs = null)
+		{
+			return
+				new Decorator(
+					ret =>
+						(reqs == null || reqs(ret)) && Me.CurrentTarget != null,
+					CastOnGround(spell, ctx => Me.CurrentTarget.Position, ctx => true));
+		}
+
+		public static Composite CastOnGround(string spell, CommonBehaviors.Retrieval<Vector3> location,
+			Selection<bool> reqs = null)
+		{
+			return
+				new Decorator(
+					ret =>
+						(reqs == null || reqs(ret)) && location != null && location(ret) != Vector3.Zero &&
+						AbilityManager.CanCast(spell, BuddyTor.Me.CurrentTarget),
+					new Action(ret => AbilityManager.Cast(spell, location(ret))));
+		}
+
+		public static Composite DoTGround(string spell, float time = 0, Selection<bool> reqs = null)
+		{
+			return DoTGround(spell, ret => BuddyTor.Me.CurrentTarget, time, reqs);
+		}
+
+
+		public static Composite DoTGround(string spell, UnitSelectionDelegate onUnit, float time, Selection<bool> reqs = null)
+		{
+			return
+				new Decorator(
+					ret => (reqs == null || reqs(ret))
+						   && onUnit != null
+						   && onUnit(ret) != null
+						   && AbilityManager.CanCast(spell, onUnit(ret))
+						   && !SpellBlackListed(spell, onUnit(ret).Guid),
+					new PrioritySelector(
+						new Action(ctx =>
+						{
+							BlackListedSpells.Add(new ExpiringItem(spell, GetCooldown(spell) + 25 + time, onUnit(ctx).Guid));
+							Logger.Write(">> Casting on Ground <<   " + spell);
+							return RunStatus.Failure;
+						}),
+						new Action(ret => AbilityManager.Cast(spell, onUnit(ret).Position))));
+		}
+
+		#endregion
+
+		#region DoT
+
+		public static Composite DoT(string spell, string debuff, float time = 0, Selection<bool> reqs = null)
+		{
+			return DoT(spell, ret => Me.CurrentTarget, debuff, time, reqs);
+		}
+
+		public static Composite DoT(string spell, UnitSelectionDelegate onUnit, string debuff, float time,
+			Selection<bool> reqs = null)
+		{
+			return
+				new Decorator(
+					ret => onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret))
+						   && !onUnit(ret).HasMyDebuff(debuff)
+						   && AbilityManager.CanCast(spell, onUnit(ret))
+						   && !SpellBlackListed(spell, onUnit(ret).Guid),
+					new PrioritySelector(
+						new Action(ctx =>
+						{
+							BlackListedSpells.Add(new ExpiringItem(spell, GetCooldown(spell) + 25 + time, onUnit(ctx).Guid));
+							Logger.Write(">> Casting <<   " + spell);
+							return RunStatus.Failure;
+						}),
+						new Action(ret => AbilityManager.Cast(spell, onUnit(ret)))));
+		}
+
+		public static float GetCastTime(string spell)
+		{
+			float castTime = 0;
+			var v = AbilityManager.KnownAbilities.FirstOrDefault(a => a.Name.Contains(spell)).CastingTime;
+			castTime += v*1000;
+			return castTime;
+		}
+
+		public static float GetCooldown(string spell)
+		{
+			float time = 0;
+			var v = AbilityManager.KnownAbilities.FirstOrDefault(a => a.Name.Contains(spell)).CooldownTime;
+			time += v*1000;
+			return time;
+		}
+
+		public static bool SpellBlackListed(string spell, float guid)
+		{
+			using (BuddyTor.Memory.AcquireFrame())
+			{
+				BlackListedSpells.RemoveAll(s => s.Item.Equals(""));
+				return BlackListedSpells.Any(s => s.Item.Equals(spell) && Math.Abs(s.TargetGuid - guid) < .01f);
+			}
+		}
+
+		#endregion
+
+		#region Heal
+
+		private static bool Target(TorCharacter onUnit)
+		{
+			onUnit.Target();
+			return true;
+		}
+
+		public static Composite Cleanse(string spell, Selection<bool> reqs = null)
+		{
+			return new Decorator(
+				ret => Targeting.DispelTarget != null && (reqs == null || reqs(ret)) && Target(Targeting.DispelTarget),
+				Cast(spell, ret => Targeting.DispelTarget, reqs));
+		}
+
+
+		public static Composite Heal(string spell, int hp = 100, Selection<bool> reqs = null)
+		{
+            return Heal(spell, onUnit => Targeting.HealTarget, hp, reqs);
+		}
+
+		public static Composite Heal(string spell, UnitSelectionDelegate onUnit, int hp = 100, Selection<bool> reqs = null)
+		{
+			return new Decorator(
+				ret =>
+					onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) && onUnit(ret).HealthPercent <= hp &&
+					Target(onUnit(ret)),
+				Cast(spell, onUnit, reqs));
+		}
+
+		public static Composite HealAoe(string spell, Selection<bool> reqs = null)
+		{
+			return new Decorator(
+				ret => (reqs == null || reqs(ret)) && Targeting.ShouldAoe && Targeting.AoeHealTarget != null,
+				Cast(spell, onUnit => Targeting.AoeHealTarget, reqs));
+		}
+
+		public static Composite HoT(string spell, int hp = 100, Selection<bool> reqs = null)
+		{
+			return new Decorator(ret => Targeting.HealTarget != null,
+				HoT(spell, onUnit => Targeting.HealTarget, hp, reqs));
+		}
+
+		public static Composite HoT(string spell, UnitSelectionDelegate onUnit, int hp = 100, Selection<bool> reqs = null)
+		{
+			return new Decorator(
+				ret =>
+					onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) && !onUnit(ret).HasMyBuff(spell) &&
+					onUnit(ret).HealthPercent <= hp,
+				Cast(spell, onUnit, reqs));
+		}
+
+		public static Composite HealGround(string spell, CanRunDecoratorDelegate reqs = null)
+		{
+			return new Decorator(
+				ret =>
+					Targeting.AoeHealPoint != Vector3.Zero && (reqs == null || reqs(ret)) &&
+					Targeting.ShouldAoe,
+				CastOnGround(spell, ret => Targeting.AoeHealPoint, ret => true));
+		}
+
+		#endregion
+	}
+
+	public class ExpiringItem
+	{
+		public string Item;
+		public ulong TargetGuid;
+
+		public ExpiringItem(string str, float milisecs, ulong g)
+		{
+			Item = str;
+			var t = new Timer(milisecs);
+			TargetGuid = g;
+			t.Elapsed += Elapsed_Event;
+			t.Start();
+		}
+
+		private void Elapsed_Event(object sender, ElapsedEventArgs e)
+		{
+			Item = "";
+		}
+	}
+}

--- a/Targeting.cs
+++ b/Targeting.cs
@@ -1,0 +1,318 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using JetBrains.Annotations;
+
+
+using Buddy.BehaviorTree;
+using Buddy.Common;
+using Buddy.CommonBot;
+using Buddy.Swtor;
+using Buddy.Swtor.Objects;
+using Buddy.Swtor.Objects.Containers;
+using Buddy.Navigation;
+using Buddywing;
+using Buddy.CommonBot.Settings;
+using Buddy.Common.Math;
+using DefaultCombat.Helpers;
+
+
+using Action = Buddy.BehaviorTree.Action;
+
+
+namespace DefaultCombat.Core
+{
+
+    public static class Targeting
+    {
+        //Collections
+        public static List<TorCharacter> HealCandidates;
+        public static List<TorCharacter> Tanks;
+        public static List<Vector3> HealCandidatePoints;
+        public static List<TorCharacter> Enemies = new List<TorCharacter>();
+        public static List<Vector3> EnemyPoints = new List<Vector3>();
+
+        //Static Points and People
+        public static string TankName = "";
+        public static string TankNameStart;
+        public static string TankNameCheck;
+        public static TorCharacter Tank;
+        public static TorCharacter HealTarget;
+        public static TorCharacter AoeHealTarget;
+        public static TorCharacter AoeDpsTarget;
+        public static TorCharacter DispelTarget;
+        private static TorPlayer Me
+        {
+            get { return BuddyTor.Me; }
+        }
+        private const int AoedpsCountNeeded = 3;
+
+        public static Vector3 AoeDpsPoint = Vector3.Zero;
+
+        //Counts
+        public static int AoeHealCount;
+        private const int AoeHealCountNeeded = 2;
+        public static int AoeDpsCount;
+        public static int AoePeanutButterCount;
+        private static int _aoepbCountNeeded = 3;
+        public static bool ShouldAoeHeal;
+        public static bool ShouldAoe;
+        public static bool ShouldPbaoe;
+
+        //Settings for making target queries
+        private const int MaxHealth = Health.Max;
+        private const float HealingDistance = Distance.Ranged;
+        private const float AoeHealDist = Distance.HealAoe;
+        private const int AoeHealHp = Health.High;
+        public static Vector3 AoeHealPoint = Vector3.Zero;
+
+        //Determine if we should use the tank's target.
+        private static bool UseTankTarget
+        {
+            get
+            {
+                return Me.CurrentTarget == null && Tank != null && Tank.Guid != Me.Guid && Tank.InCombat && Tank.CurrentTarget != null;
+            }
+        }
+
+
+        //Caching shit
+        public static int cacheCount = 75;
+        public static int maxCacheCount = 2;
+        public static List<TorCharacter> Objects;
+        public static List<TorCharacter> objects;
+        public static Composite ScanTargets
+        {
+            get
+            {
+                return new Action(delegate
+                {
+                    //increment shit!
+                    cacheCount++;
+
+                    //Reset counts
+                    AoeHealCount = 0;
+                    AoeDpsCount = 0;
+                    AoePeanutButterCount = 0;
+                    //Reset Targets
+               //     Tank = null;
+                    HealTarget = null;
+                    AoeHealTarget = null;
+                    AoeHealPoint = Vector3.Zero;
+                    DispelTarget = null;
+
+
+                    //Reset Lists and shit
+                    HealCandidates = new List<TorCharacter>();
+                    HealCandidatePoints = new List<Vector3>();
+                    EnemyPoints = new List<Vector3>();
+                    Tanks = new List<TorCharacter>();
+                    ShouldAoeHeal = false;
+                    var objects = GetTorCharacters();
+
+
+                    //update the cache when we feel like it
+                    if (cacheCount >= maxCacheCount)
+                        updateObjects();
+
+                    if (DefaultCombat.IsHealer)
+                    {
+
+                        foreach (TorCharacter p in Objects)
+                        {
+                            //Doing this shit early
+
+                            //    Logger.Write(p.Name);
+                            if (Tank != null && Tank == p)
+                                Tank = p;
+
+                            if (Tank == null && p.Name == TankName && !p.IsDead)
+                                Tank = p;
+
+                            // Got a Focus Tank?
+                            if (Tank == null && Me.FocusTargetIsActive && p.Guid == Me.FocusTargetID && !p.IsDead)
+                                Tank = p;
+
+                            if (p.IsPartyRoleTank())
+                                Tanks.Add(p);
+
+                            // Damn couldnt find a tank ima be the boss!
+
+                            if (Tank == null && Me.Companion != null)
+                                Tank = Me.Companion;
+
+                            if (Tank == null && Me.Companion == null)
+                                Tank = Me;
+
+                            //Check for HealTarget
+                            if (p.HealthPercent <= MaxHealth && !p.IsDead)
+                            {
+                                if (HealTarget == null || p.HealthPercent < HealTarget.HealthPercent)
+                                    HealTarget = p;
+
+                                //Add to candidtates list
+                                HealCandidates.Add(p);
+                                HealCandidatePoints.Add(p.Position);
+
+                                //increment our AOEHealCount
+                                if (p.HealthPercent <= AoeHealHp)
+                                    AoeHealCount++;
+                            }
+
+                            if (p.NeedsCleanse())
+                            {
+
+                                if (DispelTarget != null && p.HealthPercent < DispelTarget.HealthPercent)
+                                    DispelTarget = p;
+
+                                if (DispelTarget == null)
+                                    DispelTarget = p;
+                            }
+
+                        }
+
+
+                        //We have checked everyone out, lets set AOE stuff
+                        if (AoeHealCount >= AoeHealCountNeeded)
+                        {
+                            ShouldAoeHeal = true;
+                            //AOEHealTarget
+                            AoeHealTarget = AoeHealLocation(AoeHealDist);
+
+                            //AOEHealPoint
+                            if (AoeHealTarget != null)
+                                AoeHealPoint = AoeHealLocation(AoeHealTarget);
+                        }
+                    }
+
+                    foreach (var c in objects)
+                    {
+
+
+                        //Dps
+                        if (c.IsValidTarget())
+                        {
+                            //Enemies.Add(c);
+                            EnemyPoints.Add(c.Position);
+                        }
+
+                        if (Me.CurrentTarget != null)
+                            ShouldAoe = CheckDpsAoe(AoedpsCountNeeded, Distance.MeleeAoE, Me.CurrentTarget.Position);
+
+                        ShouldPbaoe = CheckDpsAoe(AoedpsCountNeeded, Distance.MeleeAoE, Me.Position);
+                    }
+
+
+
+
+
+                    return RunStatus.Failure;
+                });
+            }
+        }
+
+        public static void SetTank()
+        {
+            TankNameStart = Me.CurrentTarget.ToString();
+            TankNameCheck = TankNameStart.Substring(0, TankNameStart.IndexOf(','));
+
+            if (Me.CurrentTarget != null && Me.CurrentTarget.IsFriendly && !TankName.Equals(TankNameCheck))
+            {
+                TankName = TankNameStart.Substring(0, TankNameStart.IndexOf(','));
+                Logger.Write("Tank set to : " + TankName);
+                Tank = null;
+            }
+            else
+            {
+                TankName = "";
+                Tank = null;
+                Logger.Write("Cleared Tank");
+            }
+        }
+
+        private static void updateObjects()
+        {
+            if (DefaultCombat.IsHealer)
+            {
+                Objects = Me.PartyMembers(false).ToList().FindAll(p =>
+                !p.IsDead
+                && p.DistanceSqr < HealingDistance * HealingDistance
+                && p.InLineOfSight);
+
+                if (!Objects.Contains(Me))
+                    Objects.Add(Me);
+
+                if (Me.Companion != null && !Objects.Contains(Me.Companion))
+                    Objects.Add(Me.Companion);
+            }
+
+            //Reset dat count
+            cacheCount = 0;
+        }
+
+        public static List<TorCharacter> GetTorCharacters()
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                //List<TorCharacter> objects = ObjectManager.GetObjects<TorCharacter>().ToList();
+
+                /*
+                if (Me.Companion != null)
+                    objects.Add(Me.Companion);
+                */
+                var npcs = ObjectManager.GetObjects<TorNpc>();
+                var objects = npcs.Cast<TorCharacter>().ToList();
+
+                return objects;
+            }
+        }
+
+        private static Vector3 AoeHealLocation(TorCharacter p)
+        {
+            return p != null ? p.Position : Vector3.Zero;
+        }
+
+        private static TorCharacter AoeHealLocation(float dist)
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                TorCharacter pt = Me;
+
+                if (Tank != null)
+                    pt = Tank;
+
+                var currentPtCount = PointsAroundPoint(pt.Position, HealCandidatePoints, dist);
+                var tempCount = 0;
+                foreach (var p in HealCandidates)
+                {
+                    tempCount = PointsAroundPoint(p.Position, HealCandidatePoints, dist);
+                    if (p.Guid != Me.Guid && tempCount > currentPtCount)
+                    {
+                        pt = p;
+                        currentPtCount = tempCount;
+                    }
+                }
+
+                return tempCount >= AoeHealCountNeeded ? pt : null;
+            }
+        }
+
+        public static bool CheckDpsAoe(int minMobs, float distance, Vector3 center)
+        {
+            return PointsAroundPoint(center, EnemyPoints, distance) >= minMobs;
+        }
+
+        private static int PointsAroundPoint(Vector3 pt, List<Vector3> l, float dist)
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                var maxDistance = dist * dist;
+                return l.Count(p => p.DistanceSqr(pt) <= maxDistance);
+            }
+        }
+    }
+}

--- a/Telekinetics.cs
+++ b/Telekinetics.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (C) 2011-2016 Bossland GmbH
+// See the file LICENSE for the source code's detailed license
+
+using Buddy.BehaviorTree;
+using DefaultCombat.Core;
+using DefaultCombat.Helpers;
+
+namespace DefaultCombat.Routines
+{
+	internal class Telekinetics : RotationBase
+	{
+		public override string Name
+		{
+			get { return "Sage Telekinetics"; }
+		}
+
+		public override Composite Buffs
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Force Valor")
+					);
+			}
+		}
+
+		public override Composite Cooldowns
+		{
+			get
+			{
+				return new PrioritySelector(
+					Spell.Buff("Force of Will"),
+					Spell.Buff("Force Potency", ret => Me.CurrentTarget.StrongOrGreater()),
+					Spell.Buff("Mental Alacrity", ret => Me.CurrentTarget.StrongOrGreater()),
+					Spell.Buff("Force Mend", ret => Me.HealthPercent <= 80),
+					Spell.HoT("Force Armor", on => Me, 99, ret => !Me.HasDebuff("Force-imbalance") && !Me.HasBuff("Force Armor")),
+					Spell.Buff("Vindicate", ret => Me.ForcePercent < 50 && !Me.HasDebuff("Weary"))
+					);
+			}
+		}
+
+		public override Composite SingleTarget
+		{
+			get
+			{
+				return new PrioritySelector(
+					//Movement
+					CombatMovement.CloseDistance(Distance.Ranged),
+
+					//Rotation
+					Spell.Cast("Weaken Mind", ret => !Me.CurrentTarget.HasDebuff("Weaken Mind")),
+					Spell.Cast("Turbulence", ret => Me.CurrentTarget.HasDebuff("Weaken Mind")),
+					Spell.Cast("Mind Crush", ret => Me.HasBuff("Force Gust")),
+					Spell.Cast("Telekinetic Gust"),
+					Spell.Cast("Telekinetic Wave", ret => Me.HasBuff("Tidal Force")),
+					Spell.Cast("Telekinetic Burst", ret => Me.Level >= 57),
+					Spell.Cast("Disturbance", ret => Me.Level < 57),
+					Spell.Cast("Project")
+					);
+			}
+		}
+
+		public override Composite AreaOfEffect
+		{
+			get
+			{
+				return new Decorator(ret => Targeting.ShouldAoe,
+					new PrioritySelector(
+						Spell.Cast("Telekinetic Wave", ret => Me.HasBuff("Tidal Force")),
+						Spell.CastOnGround("Forcequake")
+						));
+			}
+		}
+	}
+}

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<packages>
+  <package id="log4net" version="2.0.3" targetFramework="net4" />
+</packages>


### PR DESCRIPTION
Healers will attack when they select a mob, otherwise they will heal as normal.
 Changed tank detection routine to make it less spammy for targeting.
 Healers Rejoice, you can now pull mobs and attack when using a grind profile. This wasn't available in the past with Default Combat.
 Rest is fixed to exit in background again, sendkeys no longer works for background
 Tank selection is working as it should. If companion is out he will be tank. If no companion and no tank you will become tank. F12 is fully tested and re-written to work correctly. F12 will set tank if a friendly target is selected. To clear the selection just target either a unfriendly or nothing or current f12 tank and hit f12. Bot will then go back to auto Tank selection.
 Added scavenging and bio to corpses.
 Cryo came up with the code for Stims and XP boosts when under 65.
 Dispel is tested but we have very few debuff names in the list. List is found under Helpers/Extensions.cs Public Static Debuff (If anyone ha
